### PR TITLE
Add import ESLint rules for MUI

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,12 +16,22 @@ module.exports = {
     'react-refresh'
   ],
   rules: {
+    // React
     'react-refresh/only-export-components': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'react/prop-types': 0,
     'react/display-name': 0,
 
+    // MUI
+    'no-restricted-imports': [
+      'error',
+      {
+        'patterns': ['@mui/*/*/*']
+      }
+    ],
+
+    // Common
     'no-console': 1,
     'no-lonely-if': 1,
     'no-unused-vars': 1,


### PR DESCRIPTION
Add import ESLint rules for MUI
```cjs
{
  "rules": {
    "no-restricted-imports": [
      "error",
      {
        "patterns": ["@mui/*/*/*"]
      }
    ]
  }
}

```