### PR TITLE
Config MUI theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,13 +3,17 @@ import AccessAlarmIcon from '@mui/icons-material/AccessAlarm'
 import ThreeDRotation from '@mui/icons-material/ThreeDRotation'
 import HomeIcon from '@mui/icons-material/Home'
 import { pink } from '@mui/material/colors'
+import Typography from '@mui/material/Typography'
 
 function App() {
   return (
     <>
       <div>trungquandev</div>
+
+      <Typography variant='body2' color="text.secondary">Test Typography</Typography>
+
       <Button variant="text">Text</Button>
-      <Button variant="contained">Contained</Button>
+      <Button variant="contained" color="success">Contained</Button>
       <Button variant="outlined">Outlined</Button>
 
       <br />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider } from '@mui/material/styles'
+import theme from './theme'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <CssBaseline />
-    <App />
-  </React.StrictMode>,
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
 )

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,23 @@
+import { createTheme } from '@mui/material/styles'
+import { red } from '@mui/material/colors'
+
+// Create a theme instance.
+const theme = createTheme({
+  palette: {
+    mode: 'light', // default is light
+    primary: {
+      main: '#556cd6'
+    },
+    secondary: {
+      main: '#19857b'
+    },
+    error: {
+      main: red.A400
+    },
+    text: {
+      secondary: red[500]
+    }
+  }
+})
+
+export default theme


### PR DESCRIPTION
Import typography: `import Typography from '@mui/material/Typography'`
Example: `<Typography variant='body2' color="text.secondary">Test Typography</Typography>`

Create theme instance
```js
import { createTheme } from '@mui/material/styles'
import { red } from '@mui/material/colors'

// Create a theme instance.
const theme = createTheme({
  palette: {
    mode: 'light', // default is light
    primary: {
      main: '#556cd6'
    },
    secondary: {
      main: '#19857b'
    },
    error: {
      main: red.A400
    },
    text: {
      secondary: red[500]
    }
  }
})

export default theme
```