### PR TITLE
Dark Mode and Light Mode sync with System part 1

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,28 @@ import HomeIcon from '@mui/icons-material/Home'
 import { pink } from '@mui/material/colors'
 import Typography from '@mui/material/Typography'
 
+import { useColorScheme } from '@mui/material/styles'
+
+function ModeToggle() {
+  const { mode, setMode } = useColorScheme()
+  return (
+    <Button
+      onClick={() => {
+        setMode(mode === 'light' ? 'dark' : 'light')
+        // localStorage.setItem('trello-dark-light-mode')
+        // localStorage.getItem('trello-dark-light-mode')
+      }}
+    >
+      {mode === 'light' ? 'Turn dark' : 'Turn light'}
+    </Button>
+  )
+}
+
 function App() {
   return (
     <>
+      <ModeToggle />
+      <hr />
       <div>trungquandev</div>
 
       <Typography variant='body2' color="text.secondary">Test Typography</Typography>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,14 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import CssBaseline from '@mui/material/CssBaseline'
-import { ThemeProvider } from '@mui/material/styles'
+import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
 import theme from './theme'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ThemeProvider theme={theme}>
+    <CssVarsProvider theme={theme}>
       <CssBaseline />
       <App />
-    </ThemeProvider>
+    </CssVarsProvider>
   </React.StrictMode>
 )

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,23 +1,23 @@
-import { createTheme } from '@mui/material/styles'
-import { red } from '@mui/material/colors'
+import { experimental_extendTheme as extendTheme } from '@mui/material/styles'
+import { teal, deepOrange, cyan, orange } from '@mui/material/colors'
 
 // Create a theme instance.
-const theme = createTheme({
-  palette: {
-    mode: 'light', // default is light
-    primary: {
-      main: '#556cd6'
+const theme = extendTheme({
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: teal,
+        secondary: deepOrange
+      }
     },
-    secondary: {
-      main: '#19857b'
-    },
-    error: {
-      main: red.A400
-    },
-    text: {
-      secondary: red[500]
+    dark: {
+      palette: {
+        primary: cyan,
+        secondary: orange
+      }
     }
   }
+  // ...other properties
 })
 
 export default theme


### PR DESCRIPTION
Link reference:
- https://github.com/mui/material-ui/issues/27651
- https://github.com/mui/material-ui/issues/32049#issuecomment-1173228039
- https://mui.com/material-ui/experimental-api/css-theme-variables/migration/
- https://mui.com/material-ui/experimental-api/css-theme-variables/overview/#customizing-the-theme

# How to solve Bug Flickering
Using `CssVarsProvider`:
```JSX
import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
import theme from './theme'

ReactDOM.createRoot(document.getElementById('root')).render(
  <React.StrictMode>
    <CssVarsProvider theme={theme}>
      <CssBaseline />
      <App />
    </CssVarsProvider>
  </React.StrictMode>
)

```

# Build Light Mode and Dark Mode
## 1. Add the new provider
```jsx
import { createTheme } from '@mui/material/styles'
import { experimental_extendTheme as extendTheme} from '@mui/material/styles'
import { red } from '@mui/material/colors'

// Create a theme instance.
const theme = extendTheme({
  colorSchemes: {
    light: {
      palette: {
        primary: {
          main: '#ff5252'
        }
      }
    },
    dark: {
      palette: {
        primary: {
          main: '#000'
        }
      }
    }
  }
  // ...other properties
})

export default theme
```
Then, replace the `ThemeProvider` with the `CssVarsProvider`:
```jsx
import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
import { ThemeProvider } from '@mui/material/styles'
import theme from './theme'

ReactDOM.createRoot(document.getElementById('root')).render(
  <React.StrictMode>
    <CssVarsProvider theme={theme}>
      <CssBaseline />
      <App />
    </CssVarsProvider>
  </React.StrictMode>
)
```

## 2. Remove the toggle mode logic

You can remove your existing logic that handles the user-selected mode and replace it with the `useColorScheme` hook.
```jsx
import {
  Experimental_CssVarsProvider as CssVarsProvider,
  experimental_extendTheme as extendTheme,
  useColorScheme,
} from '@mui/material/styles';

function ModeToggle() {
  const { mode, setMode } = useColorScheme();
  return (
    <Button
      onClick={() => {
        setMode(mode === 'light' ? 'dark' : 'light');
      }}
    >
      {mode === 'light' ? 'Turn dark' : 'Turn light'}
    </Button>
  );
}

const theme = extendTheme({
  // ...your custom theme
});

function App() {
  return (
    <CssVarsProvider theme={theme}>
      <ModeToggle />
      ...
    </CssVarsProvider>
  );
}
```

## 3. Prevent dark-mode flickering in server-side applications

The `getInitColorSchemeScript()` API prevents dark-mode flickering by returning a script that must be run before React.

TODO merge with other pages
```JSX
import { experimental_extendTheme as extendTheme } from '@mui/material/styles'
import { teal, deepOrange, cyan, orange } from '@mui/material/colors'

// Create a theme instance.
const theme = extendTheme({
  colorSchemes: {
    light: {
      palette: {
        primary: teal,
        secondary: deepOrange
      }
    },
    dark: {
      palette: {
        primary: cyan,
        secondary: orange
      }
    }
  }
  // ...other properties
})

export default theme
```