### PR TITLE
Fix change to absolute import

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./src/*"],
+    },
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import Board from './pages/Boards/_id'
+import Board from '~/pages/Boards/_id'
 
 function App() {
   return (

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box'
-import ModeSelect from '../../components/ModeSelect'
+import ModeSelect from '~/components/ModeSelect'
 
 function AppBar() {
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.jsx'
+import App from '~/App.jsx'
 import CssBaseline from '@mui/material/CssBaseline'
 import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
-import theme from './theme'
+import theme from '~/theme'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/pages/Boards/_id.jsx
+++ b/src/pages/Boards/_id.jsx
@@ -1,5 +1,5 @@
 import Container from '@mui/material/Container'
-import AppBar from '../../components/AppBar'
+import AppBar from '~/components/AppBar'
 import BoardBar from './BoardBar'
 import BoardContent from './BoardContent'
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,9 @@ import react from '@vitejs/plugin-react-swc'
 export default defineConfig({
   plugins: [react()],
   // base: './'
+  resolve: {
+    alias: [
+      { find: '~', replacement: '/src' }
+    ]
+  }
 })


### PR DESCRIPTION
# Problems

I have created web applications in react

For file imports in a folder tree that is not deep, relative import paths are just fine.

In many occasions as my project evolves to become larger, I begin to have more files with increasing folder depth.
Importing modules starts to create **relative import path hell**.

![image](https://github.com/quanganh2001/trello-web/assets/89558595/ca943f25-abd7-4518-810b-be1c7c2e3ff5)

You can see I have imports like: `import ModeSelect from '../../components/ModeSelect`

- This crazy import paths to a module increases cognitive effort just to trace the exact path to the module. They are hard to follow. Modern IDEs like _vscode_ are smart enough to import a module for you. But paths like `../../../../../` are quite displeasing and do not constitute to clean code.
- They break during refactoring. Should you move location of a module, things break.

# How to solve problem?

You can use absolute paths to solve these issues.

You need to configure your application to support _importing modules using absolute paths_. This can be by configuring a `jsconfig.json` or `vite.config.ts` file in the root of your project. Because I am using vite to create react app, so I just created `vite.config.ts` using `resolve.alias`

Paste in the below code to the file: `vite.config.ts`

```typescript
import { defineConfig } from 'vite'
import react from '@vitejs/plugin-react-swc'

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [react()],
  // base: './'
  resolve: {
    alias: [
      { find: '~', replacement: '/src' }
    ]
  }
})
```

When aliasing to file system paths, always use absolute paths. Relative alias values will be used as-is and will not be resolved into file system paths.

Explain: find ~ will replacement `src` folder

![image](https://github.com/quanganh2001/trello-web/assets/89558595/cf523d5e-93da-447b-b978-41793e09ca15)

![image](https://github.com/quanganh2001/trello-web/assets/89558595/bddbbc87-7d12-4e5f-9526-a38471a3661a)

Create the `jsconfig.json` and paste in the below code:

```javascript
{
  "compilerOptions": {
    "paths": {
      "~/*": ["./src/*"],
    },
  }
}
```

For styles at the same level, you should be flexible using `./`. When the styles outside many levels, you should be using absolute import.

Link references:

- [Avoid relative path import hell in react - DEV Community](https://dev.to/smitterhane/avoid-relative-path-import-hell-in-react-36in "‌")
- [Shared Options | Vite (vitejs.dev)](https://vitejs.dev/config/shared-options.html#resolve-alias "‌")
- Source code: [trungquandev-public-utilities-algorithms/09-vite-absolute-relative-import at main · trungquandev/trungquandev-public-utilities-algorithms (github.com)](https://github.com/trungquandev/trungquandev-public-utilities-algorithms/tree/main/09-vite-absolute-relative-import "‌")
- JSConfig vscode: [jsconfig.json Reference (visualstudio.com)](https://code.visualstudio.com/docs/languages/jsconfig "‌")