### PR TITLE
34. Thuật Toán Phát Hiện Va Chạm với Dnd-kit

### DIFF
--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -10,7 +10,8 @@ import {
   useSensor,
   useSensors,
   DragOverlay,
-  defaultDropAnimationSideEffects
+  defaultDropAnimationSideEffects,
+  closestCorners
 } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
 import { useEffect, useState } from 'react'
@@ -177,7 +178,12 @@ function BoardContent({ board }) {
 
   return (
     <DndContext
+      // Cảm biến (đã giải thích kỹ ở video số 30)
       sensors={sensors}
+      // Thuật toán phát hiện va chạm (nếu không có nó thì card với cover lớn sẽ không kéo qua Column được vì lúc này nó đang bị conflict giữa card và column), chúng ta sẽ dùng closestCorners thay vì closestCenter
+      // https://docs.dndkit.com/api-documentation/context-provider/collision-detection-algorithms
+      collisionDetection={closestCorners}
+
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}


### PR DESCRIPTION
Vấn đề đang gặp ở đây là cần có thuật toán phát hiện va chạm (hay còn gọi là Collision detection algorithms)

Chúng ta sẽ sử dụng Closest corners (va chạm một góc), khi kéo một phần tử nào đấy trong phạm vi 4 góc nó ăn luôn

Đôi lúc có những trường hợp phức tạp phải tự custom, tự xử lý, tự detect.

Rất may là có một thuật toán đáp ứng và fix được đó là thuật toán closest corners (va chạm góc phần tử)

Trong file `BoardContext.jsx`, thêm import: 
```jsx
import {
  DndContext,
  // PointerSensor,
  MouseSensor,
  TouchSensor,
  useSensor,
  useSensors,
  DragOverlay,
  defaultDropAnimationSideEffects,
  closestCorners
} from '@dnd-kit/core'
```

Trong phần tử `DndContext` thêm thuộc tính `collisionDectection={closestCorners}`. 

Thuật toán phát hiện va chạm (nếu không có nó thì card với cover lớn sẽ không kéo qua Column được vì lúc này nó đang bị conflict giữa card và column), chúng ta sẽ dùng `closestCorners` thay vì `closestCenter`