### PR TITLE
35. Hoàn thiện kéo thả Card trong cùng Column - Dnd-kit

### DIFF
--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -46,6 +46,7 @@ function BoardContent({ board }) {
   const [activeDragItemId, setActiveDragItemId] = useState(null)
   const [activeDragItemType, setActiveDragItemType] = useState(null)
   const [activeDragItemData, setActiveDragItemData] = useState(null)
+  const [oldColumnWhenDraggingCard, setOldColumnWhenDraggingCard] = useState(null)
 
   useEffect(() => {
     setOrderedColumns(mapOrder(board?.columns, board?.columnOrderIds, '_id'))
@@ -63,6 +64,11 @@ function BoardContent({ board }) {
     setActiveDragItemId(event?.active?.id)
     setActiveDragItemType(event?.active?.data?.current?.columnId ? ACTIVE_DRAG_ITEM_TYPE.CARD : ACTIVE_DRAG_ITEM_TYPE.COLUMN)
     setActiveDragItemData(event?.active?.data?.current)
+
+    // Nếu là kéo card thì mới thực hiện những hành động giá trị oldColumn
+    if (event?.active?.data?.current?.columnId) {
+      setOldColumnWhenDraggingCard(findColumnByCardId(event?.active?.id))
+    }
   }
 
   // Trigger trong quá trình kéo (drag) một phần tử
@@ -134,39 +140,84 @@ function BoardContent({ board }) {
   // Trigger khi kết thúc hành động kéo (drag) một phần tử => hành động thả (drop)
   const handleDragEnd = (event) => {
     // console.log('handleDragEnd: ', event)
-
-    if (activeDragItemType === ACTIVE_DRAG_ITEM_TYPE.CARD) {
-      // console.log('Hành động kéo thả Card - Tạm thời không làm gì cả!')
-      return
-    }
-
     const { active, over } = event
 
     // Cần đảm bảo nếu không tồn tại active hoặc over (khi kéo ra khỏi phạm vi container) thì không làm gì (tránh crash trang)
     if (!active || !over) return
 
-    // Nếu vị trí sau khi kéo thả khác với vị trí ban đầu
-    if (active.id !== over.id) {
-      // Lấy vị trí cũ (từ thằng active)
-      const oldIndex = orderedColumns.findIndex(c => c._id === active.id)
-      // Lấy vị trí mới (từ thằng over)
-      const newIndex = orderedColumns.findIndex(c => c._id === over.id)
+    // Xử lý kéo thả Cards
+    if (activeDragItemType === ACTIVE_DRAG_ITEM_TYPE.CARD) {
+      // activeDraggingCard: Là cái card đang được kéo
+      const { id: activeDraggingCardId, data: { current: activeDraggingCardData } } = active
+      // overCard: là cái card đang tương tác trên hoặc dưới so với cái card được kéo ở trên.
+      const { id: overCardId } = over
 
-      // Dùng arrayMove của thằng dnd-kit để sắp xếp lại mảng Columns ban đầu
-      // Code của arrayMove ở đây: dnd-kit/packages/sortable/src/utilities/arrayMove.ts
-      const dndOrderedColumns = arrayMove(orderedColumns, oldIndex, newIndex)
-      // 2 cái console.log dữ liệu này sau dùng để xử lý gọi API
-      // const dndOrderedColumnsIds = dndOrderedColumns.map(c => c._id)
-      // console.log('dndOrderedColumns: ', dndOrderedColumns)
-      // console.log('dndOrderedColumnsIds: ', dndOrderedColumnsIds)
+      // Tìm 2 cái columns theo cardId
+      const activeColumn = findColumnByCardId(activeDraggingCardId)
+      const overColumn = findColumnByCardId(overCardId)
 
-      // Cập nhật lại state columns ban đầu sau khi đã kéo thả
-      setOrderedColumns(dndOrderedColumns)
+      // Nếu không tồn tại 1 trong 2 columns thì không làm gì hết, tránh crash trang web
+      if (!activeColumn || !overColumn) return
+
+      // Hành động kéo thả card qua 2 column khác nhau
+      // Phải dùng tới activeDragItemData.columnId hoặc oldColumnWhenDraggingCard._id (set vào state từ bước handleDragStart) chứ không phải activeData, trong scope handleDragEnd này vì sau khi đi qua onDragOver tới đây là state của card đã bị cập nhật một lần rồi
+      if (oldColumnWhenDraggingCard._id !== overColumn._id) {
+        //
+      } else {
+        // Hành động kéo thả card trong cùng một cái column
+
+        // Lấy vị trí cũ (từ thằng oldColumnWhenDraggingCard)
+        const oldCardIndex = oldColumnWhenDraggingCard?.cards?.findIndex(c => c._id === activeDragItemId)
+        // Lấy vị trí mới (từ thằng overColumn)
+        const newCardIndex = overColumn?.cards?.findIndex(c => c._id === overCardId)
+
+        // Dùng arrayMove vì kéo card trong một cái column thì tương tự với logic kéo column trong một cái board content
+        const dndOrderedCards = arrayMove(oldColumnWhenDraggingCard?.cards, oldCardIndex, newCardIndex)
+
+        setOrderedColumns(prevColumns => {
+          // Clone mảng OrderedColumnsState cũ ra một cái mới để xử lý data rồi return - cập nhật lại OrderedColumnsState mới
+          const nextColumns = cloneDeep(prevColumns)
+
+          // Tìm tới cái Column mà chúng ta đang thả
+          const targetColumn = nextColumns.find(column => column._id === overColumn._id)
+
+          // Cập nhật lại 2 giá trị mới là card và cardOrderIds trong cái targetColumn
+          targetColumn.cards = dndOrderedCards
+          targetColumn.cardOrderIds = dndOrderedCards.map(card => card._id)
+
+          // Trả về giá trị state mới (chuẩn vị trí)
+          return nextColumns
+        })
+      }
     }
 
+    // Xử lý kéo thả Column trong một cái boardContent
+    if (activeDragItemType === ACTIVE_DRAG_ITEM_TYPE.COLUMN) {
+      // Nếu vị trí sau khi kéo thả khác với vị trí ban đầu
+      if (active.id !== over.id) {
+        // Lấy vị trí cũ (từ thằng active)
+        const oldColumnIndex = orderedColumns.findIndex(c => c._id === active.id)
+        // Lấy vị trí mới (từ thằng over)
+        const newColumnIndex = orderedColumns.findIndex(c => c._id === over.id)
+
+        // Dùng arrayMove của thằng dnd-kit để sắp xếp lại mảng Columns ban đầu
+        // Code của arrayMove ở đây: dnd-kit/packages/sortable/src/utilities/arrayMove.ts
+        const dndOrderedColumns = arrayMove(orderedColumns, oldColumnIndex, newColumnIndex)
+        // 2 cái console.log dữ liệu này sau dùng để xử lý gọi API
+        // const dndOrderedColumnsIds = dndOrderedColumns.map(c => c._id)
+        // console.log('dndOrderedColumns: ', dndOrderedColumns)
+        // console.log('dndOrderedColumnsIds: ', dndOrderedColumnsIds)
+
+        // Cập nhật lại state columns ban đầu sau khi đã kéo thả
+        setOrderedColumns(dndOrderedColumns)
+      }
+    }
+
+    // Những dữ liệu sau khi kéo thả này luôn phải đưa về giá trị null mặc định ban đầu
     setActiveDragItemId(null)
     setActiveDragItemType(null)
     setActiveDragItemData(null)
+    setOldColumnWhenDraggingCard(null)
   }
 
   /**


### PR DESCRIPTION
# Xử lý kéo thả Cards

Do chúng ta set state rồi, nên khi đến bước kéo đã bị set state lại rồi

Quy trình kéo thả:

- dragStart: Lưu lại dữ liệu Column gốc ban đầu vào một state riêng
- dragOver: (dragOver sẽ cập nhật (State đã cập nhật một lần) )
- dragEnd: muốn dùng column gốc ban đầu thì chúng ta phải đi vào state để lấy column gốc ban đầu (chứ không dùng được active column trong kết quả của `dragEnd`.

Tạo state mới: `const [oldColumnWhenDraggingCard, setOldColumnWhenDraggingCard] = useState(null)`

Trường hợp kéo card thì set, ngược lại không cần set. Chúng ta sẽ sử dụng vòng lặp if, nếu là kéo card thì mới thực hiện những hành động giá trị `oldColumn.`Lưu ý bước cuối cùng phải set về giá trị null mặc định ban đầu

```jsx
// Nếu là kéo card thì mới thực hiện những hành động giá trị oldColumn
if (event?.active?.data?.current?.columnId) {
  setOldColumnWhenDraggingCard(findColumnByCardId(event?.active?.id))
}
```

Kéo card qua 2 column khác nhau thì Phải dùng tới `activeDragItemData` (set vào state từ bước `handleDragStart`) chứ không phải `activeData`, trong scope `handleDragEnd` này vì sau khi đi qua `onDragOver` tới đây là state của card đã bị cập nhật một lần rồi. Chúng ta kéo card trong một column không khác gì kéo một column trong `boardContent`

Khi có được 2 vị trí rồi, chúng ta sẽ sử dụng `arrayMove` vì kéo card trong một cái column thì tương tự với logic kéo column trong một cái board content.

Cuối cùng cập nhật lại state sẽ chuẩn ngay

- Đầu tiên clone mảng cũ ra một cái mới để xử lý data lỗi return - cập nhật lại
- Tiếp theo tìm tới cái Column mà chúng ta đang thả

Việc còn lại sẽ cập nhật lại dữ liệu card và `cardOrderIds` trước khi return `nextColumns`

```jsx
// Kéo card qua 2 column khác nhau
// Phải dùng tới activeDragItemData.columnId hoặc oldColumnWhenDraggingCard._id (set vào state từ bước handleDragStart) chứ không phải activeData, trong scope handleDragEnd này vì sau khi đi qua onDragOver tới đây là state của card đã bị cập nhật một lần rồi
console.log('activeDragItemData: ', activeDragItemData)
if (oldColumnWhenDraggingCard._id !== overColumn._id) {
  //
} else {
  // Hành động kéo thả card trong cùng một cái column

  // Lấy vị trí cũ (từ thằng oldColumnWhenDraggingCard)
  const oldCardIndex = oldColumnWhenDraggingCard?.cards?.findIndex(c => c._id === activeDragItemId)
  // Lấy vị trí mới (từ thằng overColumn)
  const newCardIndex = overColumn?.cards?.findIndex(c => c._id === overCardId)

  // Dùng arrayMove vì kéo card trong một cái column thì tương tự với logic kéo column trong một cái board content
  const dndOrderedCards = arrayMove(oldColumnWhenDraggingCard?.cards, oldCardIndex, newCardIndex)

  setOrderedColumns(prevColumns => {
    // Clone mảng OrderedColumnsState cũ ra một cái mới để xử lý data rồi return - cập nhật lại OrderedColumnsState mới
    const nextColumns = cloneDeep(prevColumns)

    // Tìm tới cái Column mà chúng ta đang thả
    const targetColumn = nextColumns.find(column => column._id === overColumn._id)

    // Cập nhật lại 2 giá trị mới là card và cardOrderIds trong cái targetColumn
    targetColumn.cards = dndOrderedCards

    targetColumn.cardOrderIds = dndOrderedCards.map(card => card._id)
    // Trả về giá trị state mới (chuẩn vị trí)
    return nextColumns
  })
}
```

![image](https://github.com/quanganh2001/trello-web/assets/89558595/28ea9aff-ff3e-42e1-8173-dda1e1873a9d)
