### PR TITLE
37. Xử lý Bug rất dị khi kéo thả - Dnd-kit (Fix flickering bug)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,7 @@ module.exports = {
 
     // Common
     'no-console': 1,
+    'no-extra-boolean-cast': 0,
     'no-lonely-if': 1,
     'no-unused-vars': 1,
     'no-trailing-spaces': 1,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+// import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from '~/App.jsx'
 import CssBaseline from '@mui/material/CssBaseline'
@@ -6,10 +6,10 @@ import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/s
 import theme from '~/theme'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <CssVarsProvider theme={theme}>
-      <CssBaseline />
-      <App />
-    </CssVarsProvider>
-  </React.StrictMode>
+  // <React.StrictMode>
+  <CssVarsProvider theme={theme}>
+    <CssBaseline />
+    <App />
+  </CssVarsProvider>
+  // </React.StrictMode>
 )


### PR DESCRIPTION
Nguồn:

- Link github issue của một người khác cũng bị: [https://github.com/clauderic/dnd-kit/issues/1128](https://github.com/clauderic/dnd-kit/issues/1128 "smartCard-inline")
- Custom thuật toán phát hiện va chạm nâng cao: [https://docs.dndkit.com/api-documentation/context-provider/collision-detection-algorithms#custom-collision-detection-algorithms](https://docs.dndkit.com/api-documentation/context-provider/collision-detection-algorithms#custom-collision-detection-algorithms "smartCard-inline")
- MultipleContainers example (line 195): [https://github.com/clauderic/dnd-kit/blob/master/stories/2%20-%20Presets/Sortable/MultipleContainers.tsx](https://github.com/clauderic/dnd-kit/blob/master/stories/2%20-%20Presets/Sortable/MultipleContainers.tsx "smartCard-inline")
- Eslint rule: No extra boolean cast: [https://eslint.org/docs/latest/rules/no-extra-boolean-cast](https://eslint.org/docs/latest/rules/no-extra-boolean-cast "smartCard-inline")

Ở đây chúng ta sẽ sử dụng `useCallback` nhận arrow function là tham số 1, mảng dependency là tham số thứ 2. Khi dependency thay đổi thì function mới chạy, ngược lại dùng kết quả cũ. Nó sẽ tối ưu performance của ứng dụng.

Chúng ta sẽ sẽ custom lại chiến lược / thuật toán phát hiện va chạm tối ưu cho việc kéo thả card giữa nhiều columns (video 37 fix bug quan trọng)

Nó sẽ nhận args (arguments là các tham số)

Tiếp theo, ta tìm các điểm giao nhau, va chạm, intersections với con trỏ, tạo hàm thuật toán phát hiện va chạm sẽ trả về một mảng các va chạm ở đây và sẽ trả về array

Tìm overId đầu tiên trong đám intersections ở trên, nếu tồn tại `overId`, trả về mảng object id là `overId`.

Nó cần `lastOverId` để khi giá trị là null, tìm đến để trả về, ngược lại trả về rỗng. (sử dụng `useRef` trong react)

Trước khi return về cho `lastOverId.current` (`useRef` sẽ sử dụng current làm giá trị). Nếu như tồn tại `lastOverId.current` thì trả về mảng JSON Object có id, ngược lại mảng rỗng

```jsx
// Chúng ta sẽ custom lại chiến lược / thuật toán phát hiện va chạm tối ưu cho việc kéo thả card giữa nhiều columns (video 37 fix bug quan trọng)
// args = arguments = Các Đối số, tham số
const collisionDetectionStrategy = useCallback((args) => {
  if (activeDragItemType === ACTIVE_DRAG_ITEM_TYPE.COLUMN) {
    // Trường hợp kéo column thì dùng thuật toán closestCorners là chuẩn nhất
    return closestCorners({ ...args })
  }

  // Tìm các điểm giao nhau, va chạm, intersections với con trỏ
  const pointerIntersections = pointerWithin(args)

  // Thuật toán phát hiện va chạm sẽ trả về một mảng các va chạm ở đây
  const intersections = !!pointerIntersections?.length
    ? pointerIntersections
    : rectIntersection(args)

  // Tìm overId đầu tiên trong đám intersections ở trên
  let overId = getFirstCollision(intersections, 'id')
  if (overId) {
    // Video 37: Đoạn này sẽ fix cái vụ flickering nhé.
    // Nếu cái over nó là custom thì sẽ tìm tới cái cardId gần nhất bên trong khu vực va chạm đó đưa vào thuật toán va chạm closestCenter hoặc closestCorners đều được. Tuy nhiên ở đây dùng closestCenter mình thấy mượt mà hơn.
    const checkColumn = orderedColumns.find(column => column._id === overId)
    if (checkColumn) {
      // console.log('overId before: ', overId)
      overId = closestCenter({
        ...args,
        droppableContainers: args.droppableContainers.filter(container => {
          return (container.id !== overId) && (checkColumn?.cardOrderIds?.includes(container.id))
        })
      })[0]?.id
      // console.log('overId after: ', overId)
    }

    lastOverId.current = overId
    return [{ id: overId }]
  }

  // Nếu overId là null thì trả về mảng rỗng - tránh bug crash trang
  return lastOverId.current ? [{ id: lastOverId.current }] : []
}, [activeDragItemType, orderedColumns])
```

Chú ý nếu để hai dấu chấm than sẽ bị báo lỗi `no-extra-boolean-cast`, lúc này các bạn cần phải thêm rule trong file `.eslinttrc.cjs` trong phần common để giá trị là số 0.

```
'no-extra-boolean-cast': 0,
```

Nếu cái over nó là custom thì sẽ tìm tới cái `cardId` gần nhất bên trong khu vực va chạm đó đưa vào thuật toán va chạm `closestCenter` hoặc `closestCorners` đều được. Tuy nhiên ở đây dùng `closestCenter` mình thấy mượt mà hơn.