### PR TITLE
37.1. Xử lý triệt để Bug nhấp nháy khi kéo thả (Flickering Bug)

### DIFF
--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -12,9 +12,9 @@ import {
   DragOverlay,
   defaultDropAnimationSideEffects,
   closestCorners,
-  closestCenter,
+  // closestCenter,
   pointerWithin,
-  rectIntersection,
+  // rectIntersection,
   getFirstCollision
 } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
@@ -277,23 +277,28 @@ function BoardContent({ board }) {
       return closestCorners({ ...args })
     }
 
-    // Tìm các điểm giao nhau, va chạm, intersections với con trỏ
+    // Tìm các điểm giao nhau, va chạm, trả về một mảng các va chạm - intersections với con trỏ
     const pointerIntersections = pointerWithin(args)
 
-    // Thuật toán phát hiện va chạm sẽ trả về một mảng các va chạm ở đây
-    const intersections = !!pointerIntersections?.length
-      ? pointerIntersections
-      : rectIntersection(args)
+    // Video 37.1: Nếu pointerIntersections là mảng rỗng, return luôn không làm gì hết
+    // Fix triệt để cái bug flickering của thư viện Dnd-kit trong trường hợp sau:
+    // - Kéo một cái card có image cover lớn và kéo lên phía trên cùng ra khỏi khu vực kéo thả
+    if (!pointerIntersections?.length) return
 
-    // Tìm overId đầu tiên trong đám intersections ở trên
-    let overId = getFirstCollision(intersections, 'id')
+    // // Thuật toán phát hiện va chạm sẽ trả về một mảng các va chạm ở đây (không cần bước này nữa - video số 37.1)
+    // const intersections = !!pointerIntersections?.length
+    //   ? pointerIntersections
+    //   : rectIntersection(args)
+
+    // Tìm overId đầu tiên trong đám pointerIntersections ở trên
+    let overId = getFirstCollision(pointerIntersections, 'id')
     if (overId) {
       // Video 37: Đoạn này sẽ fix cái vụ flickering nhé.
-      // Nếu cái over nó là custom thì sẽ tìm tới cái cardId gần nhất bên trong khu vực va chạm đó đưa vào thuật toán va chạm closestCenter hoặc closestCorners đều được. Tuy nhiên ở đây dùng closestCenter mình thấy mượt mà hơn.
+      // Nếu cái over nó là custom thì sẽ tìm tới cái cardId gần nhất bên trong khu vực va chạm đó đưa vào thuật toán va chạm closestCenter hoặc closestCorners đều được. Tuy nhiên ở đây dùng closestCorners mình thấy mượt mà hơn.
       const checkColumn = orderedColumns.find(column => column._id === overId)
       if (checkColumn) {
         // console.log('overId before: ', overId)
-        overId = closestCenter({
+        overId = closestCorners({
           ...args,
           droppableContainers: args.droppableContainers.filter(container => {
             return (container.id !== overId) && (checkColumn?.cardOrderIds?.includes(container.id))


### PR DESCRIPTION
Source:

- Card flickering when center of draggable at the equal distance between other draggables issue: [https://github.com/clauderic/dnd-kit/issues/1128](https://github.com/clauderic/dnd-kit/issues/1128 "‌")
- Collision flickering in multiple container sortable in the stories issue: [https://github.com/clauderic/dnd-kit/issues/1213#issuecomment-1691708378](https://github.com/clauderic/dnd-kit/issues/1213#issuecomment-1691708378 "smartCard-inline")

Vấn đề là khi kéo xuống phía dưới không bị ảnh hưởng, còn khi kéo lên trên cũng bị dính lỗi

Lỗi này sẽ không gặp khi chỉ có card không có ảnh, còn khi kéo một cái card có ảnh bìa lớn và kéo lên phía trên cùng ra khỏi khu vực kéo thả thì mới bị lỗi bug.

Vì vậy cách khắc phục lỗi nhấp nháy này là chúng ta sẽ kiểm tra điều kiện nếu `pointerIntersections` là mảng rỗng, return luôn không làm gì hết

```jsx
if (!pointerIntersections?.length) return
```

Chúng ta sẽ không cần thuật toán phát hiện va chạm sẽ trả về một mảng các va chạm ở đây.

Nếu cái over nó là custom thì sẽ tìm tới cái `cardId`gần nhất bên trong khu vực va chạm đó đưa vào thuật toán va chạm `closestCenter`hoặc `closestCorners` đều được. Tuy nhiên ở đây dùng `closestCorners` mình thấy mượt mà hơn.