### PR TITLE
37.2 Xử lý Bug khi Column rỗng không chứa Card

### DIFF
--- a/src/apis/mock-data.js
+++ b/src/apis/mock-data.js
@@ -10,7 +10,7 @@ export const mockData = {
     type: 'public', // 'private'
     ownerIds: [], // Những users là Admin của board
     memberIds: [], // Những users là member bình thường của board
-    columnOrderIds: ['column-id-01', 'column-id-02', 'column-id-03'], // Thứ tự sắp xếp / vị trí của các Columns trong 1 boards
+    columnOrderIds: ['column-id-01', 'column-id-02', 'column-id-03', 'column-id-04'], // Thứ tự sắp xếp / vị trí của các Columns trong 1 boards
     columns: [
       {
         _id: 'column-id-01',
@@ -57,6 +57,29 @@ export const mockData = {
           { _id: 'card-id-11', boardId: 'board-id-01', columnId: 'column-id-03', title: 'Title of card 11', description: null, cover: null, memberIds: [], comments: [], attachments: [] },
           { _id: 'card-id-12', boardId: 'board-id-01', columnId: 'column-id-03', title: 'Title of card 12', description: null, cover: null, memberIds: [], comments: [], attachments: [] },
           { _id: 'card-id-13', boardId: 'board-id-01', columnId: 'column-id-03', title: 'Title of card 13', description: null, cover: null, memberIds: [], comments: [], attachments: [] }
+        ]
+      },
+      {
+        _id: 'column-id-04',
+        boardId: 'board-id-01',
+        title: 'Empty Column 04',
+        /**
+         * Video 37.2: Cách xử lý bug logic thư viện Dnd-kit khi Column là rỗng:
+         * Phía FE sẽ tự tạo ra một cái card đặc biệt: Placeholder Card, không liên quan tới Back-end
+         * Card đặc biệt này sẽ được ẩn ở giao diện UI người dùng
+         * Cấu trúc Id của cái card này để Unique rất đơn giản, không cần phải làm random phức tạp:
+         * "columnId-placeholder-card" (mỗi column chỉ có thể có tối đa một cái Placeholder Card)
+         * Quan trọng khi tạo: phải đầy đủ: (_id, boardId, columnId, FE_PlaceholderCard)
+         * Kỹ hơn nữa về cách tạo chuẩn ở bước nào thì sẽ ở học phần tích hợp API Back-end vào dự án. (bởi vì đây là file mock-data)
+         */
+        cardOrderIds: ['column-id-04-placeholder-card'],
+        cards: [
+          {
+            _id: 'column-id-04-placeholder-card',
+            boardId: 'board-id-01',
+            columnId: 'column-id-04',
+            FE_PlaceholderCard: true
+          }
         ]
       }
     ]

--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -19,7 +19,8 @@ import {
 } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, isEmpty } from 'lodash'
+import { generatePlaceholderCard } from '~/utils/formatters'
 
 import Column from './ListColumns/Column/Column'
 import Card from './ListColumns/Column/ListCards/Card/Card'
@@ -95,6 +96,12 @@ function BoardContent({ board }) {
       if (nextActiveColumn) {
         // Xóa card ở cái column active (cũng có thể hiểu là column cũ, cái lúc mà kéo card ra khỏi nó để sang column khác)
         nextActiveColumn.cards = nextActiveColumn.cards.filter(card => card._id !== activeDraggingCardId)
+
+        // Thêm Placeholder Card nếu Column rỗng: Bị kéo hết Card đi, không còn cái nào nữa (Video 37.2)
+        if (isEmpty(nextActiveColumn.cards)) {
+          nextActiveColumn.cards = [generatePlaceholderCard(nextActiveColumn)]
+        }
+
         // Cập nhật lại mảng cardOrderIds cho chuẩn dữ liệu
         nextActiveColumn.cardOrderIds = nextActiveColumn.cards.map(card => card._id)
       }
@@ -111,6 +118,10 @@ function BoardContent({ board }) {
         }
         // Tiếp theo là thêm cái card đang kéo vào overColumn theo vị trí index mới
         nextOverColumn.cards = nextOverColumn.cards.toSpliced(newCardIndex, 0, rebuild_activeDraggingCardData)
+
+        // Xóa cái Placeholder Card đi nếu nó đang tồn tại (Video 37.2)
+        nextOverColumn.cards = nextOverColumn.cards.filter(card => !card.FE_PlaceholderCard)
+
         // Cập nhật lại mảng cardOrderIds cho chuẩn dữ liệu
         nextOverColumn.cardOrderIds = nextOverColumn.cards.map(card => card._id)
       }

--- a/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
@@ -36,7 +36,10 @@ function Card({ card }) {
       sx={{
         cursor: 'pointer',
         boxShadow: '0 1px 1px rgba(0, 0, 0, 0.2)',
-        overflow: 'unset'
+        overflow: 'unset',
+        display: card?.FE_PlaceholderCard ? 'none' : 'block'
+        // overflow: card?.FE_PlaceholderCard ? 'hidden' : 'unset',
+        // height: card?.FE_PlaceholderCard ? '8px' : 'unset'
       }}
     >
       {card?.cover && <CardMedia sx={{ height: 140 }} image={card?.cover} /> }

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -9,3 +9,20 @@ export const capitalizeFirstLetter = (val) => {
   if (!val) return ''
   return `${val.charAt(0).toUpperCase()}${val.slice(1)}`
 }
+
+/**
+ * Video 37.2 hàm generatePlaceholderCard: Cách xử lý bug logic thư viện Dnd-kit khi Column là rỗng:
+ * Phía FE sẽ tự tạo ra một cái card đặc biệt: Placeholder Card, không liên quan tới Back-end
+ * Card đặc biệt này sẽ được ẩn ở giao diện UI người dùng
+ * Cấu trúc Id của cái card này để Unique rất đơn giản, không cần phải làm random phức tạp:
+ * "columnId-placeholder-card" (mỗi column chỉ có thể có tối đa một cái Placeholder Card)
+ * Quan trọng khi tạo: phải đầy đủ: (_id, boardId, columnId, FE_PlaceholderCard)
+ */
+export const generatePlaceholderCard = (column) => {
+  return {
+    _id: `${column._id}-placeholder-card`,
+    boardId: column.boardId,
+    columnId: column._id,
+    FE_PlaceholderCard: true
+  }
+}


### PR DESCRIPTION
Chúng ta sẽ xử lý Column không có card, để xử lý tốt thì sẽ khá là phức tạp, nó liên quan đến thư viện của Dnd-kit (nó base) nên xử lý logic sẽ phức tạp, nhưng bù lại kỹ năng sẽ nâng cao và giỏi hơn.

Vì thế cách fix mình sẽ tạo bản ghi card trong column empty, dĩ nhiên nó sẽ là card đặc biệt (chỉ làm Front-end và ẩn nó đi). Nó chỉ tồn tại id, boardId và columnId. Card này do front-end tạo ra (không phải back-end). Tạo biến `FE_PlaceholderCard: true` để nhận biết card giữ chỗ, sau này các bạn đọc code sẽ không bị nhầm lẫn.

Phía FE sẽ tự tạo ra một cái card đặc biệt: Placeholder Card, không liên quan tới Back-end

- Card đặc biệt này sẽ được ẩn ở giao diện UI người dùng
- Cấu trúc Id của cái card này để Unique rất đơn giản, không cần phải làm random phức tạp:
- `"columnId-placeholder-card"` (mỗi column chỉ có thể có tối đa một cái Placeholder Card)
- Quan trọng khi tạo: phải đầy đủ: (`_id`, `boardId`, `columnId`, `FE_PlaceholderCard`)
- Kỹ hơn nữa về cách tạo chuẩn ở bước nào thì sẽ ở học phần tích hợp API Back-end vào dự án. (bởi vì đây là file mock-data)

```jsx
{
  _id: 'column-id-04',
  boardId: 'board-id-01',
  title: 'Empty Column 04',
  /**
    * Video 37.2: Cách xử lý bug logic thư viện Dnd-kit khi Column là rỗng:
    * Phía FE sẽ tự tạo ra một cái card đặc biệt: Placeholder Card, không liên quan tới Back-end
    * Card đặc biệt này sẽ được ẩn ở giao diện UI người dùng
    * Cấu trúc Id của cái card này để Unique rất đơn giản, không cần phải làm random phức tạp:
    * "columnId-placeholder-card" (mỗi column chỉ có thể có tối đa một cái Placeholder Card)
    * Quan trọng khi tạo: phải đầy đủ: (_id, boardId, columnId, FE_PlaceholderCard)
    * Kỹ hơn nữa về cách tạo chuẩn ở bước nào thì sẽ ở học phần tích hợp API Back-end vào dự án. (bởi vì đây là file mock-data)
    */
  cardOrderIds: ['column-id-04-placeholder-card'],
  cards: [
    {
      _id: 'column-id-04-placeholder-card',
      boardId: 'board-id-01',
      columnId: 'column-id-04',
      FE_PlaceholderCard: true
    }
  ]
}
```

# Xử lý ẩn hiện Card

Cho `display: card?.FE_PlaceholderCard ? 'none' : 'block'`

Tiếp theo chúng ta sẽ xử lý hành động kéo thả card giữa 2 column khác nhau đều gọi `moveCardBetweenDifferentColumns`

Chúng ta sẽ xử lý thêm một cái card giữ chỗ nếu nó là card cuối cùng kéo khỏi nó, chúng ta đang làm hai bước nên cần một bước giữa nữa đó là thêm placeholder card nếu column rỗng (tức là bị kéo hết Card đi, không còn cái nào nữa)

Trong package lodash có thêm hàm `isEmpty` check cả array, JSON object nên rất tiện

Nếu `nextActiveColumn` rỗng thì thêm card giữ chỗ

Code hàm giữ chỗ nhận column rồi trả về như trên giống như những gì đã làm trong mock data (id card placeholder kết hợp giữa columnId-placeholder-card) luôn luôn chứa một mình

```
/**
  * Video 37.2 hàm generatePlaceholderCard: Cách xử lý bug logic thư viện Dnd-kit khi Column là rỗng:
  * Phía FE sẽ tự tạo ra một cái card đặc biệt: Placeholder Card, không liên quan tới Back-end
  * Card đặc biệt này sẽ được ẩn ở giao diện UI người dùng
  * Cấu trúc Id của cái card này để Unique rất đơn giản, không cần phải làm random phức tạp:
  * "columnId-placeholder-card" (mỗi column chỉ có thể có tối đa một cái Placeholder Card)
  * Quan trọng khi tạo: phải đầy đủ: (_id, boardId, columnId, FE_PlaceholderCard)
 */
export const generatePlaceholderCard = (column) => {
  return {
    _id: `${column._id}-placeholder-card`,
    boardId: column.boardId,
    columnId: column._id,
    FE_PlaceholderCard: true
  }
}
```

```jsx
// Thêm Placeholder Card nếu Column rỗng: Bị kéo hết Card đi, không còn cái nào nữa (Video 37.2)
if (isEmpty(nextActiveColumn.cards)) {
  nextActiveColumn.cards = [generatePlaceholderCard(nextActiveColumn)]
}
```

Thêm bước nữa để cẩn thận hơn, ví dụ có ít nhất một card thì xóa hết card giữ chỗ đi để sau này đẩy lên back-end cho nó chuẩn. Ở phần `nextOverColumn` là cái column được chúng ta kéo đến chúng ta sẽ thêm một bước giữa là xóa cái placeholder card đi nếu nó đang tồn tại (lọc ra mảng `nextOverColumn.cards`, những card nào không phải placeholder thì giữ lại, ngược lại thì bỏ nó đi nhanh gọn)