### PR TITLE
64.1 Fix Bug kéo thả khi cần bôi đen Text bằng chuột

### DIFF
--- a/src/customHooks/index.js
+++ b/src/customHooks/index.js
@@ -1,0 +1,4 @@
+/**
+ * Youtube: Trungquandev - Một Lập Trình Viên
+ * Created by trungquandev.com's author on Nov 12, 2023
+ */

--- a/src/customLibraries/DndKitSensors.js
+++ b/src/customLibraries/DndKitSensors.js
@@ -1,0 +1,24 @@
+import {
+  MouseSensor as DndKitMouseSensor,
+  TouchSensor as DndKitTouchSensor
+} from '@dnd-kit/core'
+
+// Block DnD event propagation if element have "data-no-dnd" attribute
+const handler = ({ nativeEvent: event }) => {
+  let cur = event.target
+  while (cur) {
+    if (cur.dataset && cur.dataset.noDnd) {
+      return false
+    }
+    cur = cur.parentElement
+  }
+  return true
+}
+
+export class MouseSensor extends DndKitMouseSensor {
+  static activators = [{ eventName: 'onMouseDown', handler }]
+}
+
+export class TouchSensor extends DndKitTouchSensor {
+  static activators = [{ eventName: 'onTouchStart', handler }]
+}

--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -5,8 +5,8 @@ import { mapOrder } from '~/utils/sorts'
 import {
   DndContext,
   // PointerSensor,
-  MouseSensor,
-  TouchSensor,
+  // MouseSensor,
+  // TouchSensor,
   useSensor,
   useSensors,
   DragOverlay,
@@ -17,6 +17,8 @@ import {
   // rectIntersection,
   getFirstCollision
 } from '@dnd-kit/core'
+import { MouseSensor, TouchSensor } from '~/customLibraries/DndKitSensors'
+
 import { arrayMove } from '@dnd-kit/sortable'
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { cloneDeep, isEmpty } from 'lodash'

--- a/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
@@ -177,6 +177,7 @@ function Column({ column }) {
                 size='small'
                 variant='outlined'
                 autoFocus
+                data-no-dnd="true"
                 value={newCardTitle}
                 onChange={(e) => setNewCardTitle(e.target.value)}
                 sx={{
@@ -198,6 +199,7 @@ function Column({ column }) {
               />
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <Button
+                  data-no-dnd="true"
                   onClick={addNewCard}
                   variant='contained' color='success' size='small'
                   sx={{


### PR DESCRIPTION
Bug ngày hôm nay đó là khi chúng ta dùng chuột bôi một phần nào đó, thì bị lỗi chuyển sang kéo thả.

Đối với những phần tử chúng ta không muốn kéo thả, ví dụ như TextField, chúng ta muốn giữ chuột để bôi đen text, thì hiện tại đang bị Bug ăn vào event kéo thả của thư viện.

Nguồn: [https://github.com/clauderic/dnd-kit/issues/477](https://github.com/clauderic/dnd-kit/issues/477 "smartCard-inline")

Cách fix lỗi như sau:

```typescript
import { MouseSensor as LibMouseSensor, TouchSensor as LibTouchSensor } from '@dnd-kit/core';
import { MouseEvent, TouchEvent } from 'react';

// Block DnD event propagation if element have "data-no-dnd" attribute
const handler = ({ nativeEvent: event }: MouseEvent | TouchEvent) => {
    let cur = event.target as HTMLElement;

    while (cur) {
        if (cur.dataset && cur.dataset.noDnd) {
            return false;
        }
        cur = cur.parentElement as HTMLElement;
    }

    return true;
};

export class MouseSensor extends LibMouseSensor {
    static activators = [{ eventName: 'onMouseDown', handler }] as typeof LibMouseSensor['activators'];
}

export class TouchSensor extends LibTouchSensor {
    static activators = [{ eventName: 'onTouchStart', handler }] as typeof LibTouchSensor['activators'];
}
```

Tạo 2 folder `customHooks` và `customLibraries`. Copy code typescript và chuyển đổi thành javascript:

```js
import {
  MouseSensor as DndKitMouseSensor,
  TouchSensor as DndKitTouchSensor
} from '@dnd-kit/core'

// Block DnD event propagation if element have "data-no-dnd" attribute
const handler = ({ nativeEvent: event }) => {
  let cur = event.target
  while (cur) {
    if (cur.dataset && cur.dataset.noDnd) {
      return false
    }
    cur = cur.parentElement
  }
  return true
}

export class MouseSensor extends DndKitMouseSensor {
  static activators = [{ eventName: 'onMouseDown', handler }]
}

export class TouchSensor extends DndKitTouchSensor {
  static activators = [{ eventName: 'onTouchStart', handler }]
}
```

Hàm `handler` sẽ chặn sự kiện DnD nếu phần tử có`"data-no-dnd"` attribute. Trong hàm này lấy `event.target`, kiểm tra dataset nếu tồn tại `noDnd` thì chuyển xuống dạng camel case, return false, không handler sự kiện nữa.

Trong file `Column.jsx`, thêm `data-no-dnd="true"`

Tham khảo các usehooks khác: [https://usehooks.com/](https://usehooks.com/ "smartCard-inline")